### PR TITLE
Try fixing broken image in IP1

### DIFF
--- a/Assignments/ip1/ip1.md
+++ b/Assignments/ip1/ip1.md
@@ -40,7 +40,7 @@ Start by [downloading the starter code]({{site.baseurl}}{% link /Assignments/ip1
 
 You may see the following warnings:
 
-![image](./npm-warnings.jpg)
+![image]({{site.baseurl}}{% link /Assignments/ip1/npm-warnings.jpg %})
 
 You can safely ignore these warnings: the assignment works with npm 10, and the vulnerabilities are not relevant for this assignment. (Do **not** run `npm audit fix` or `npm audit fix --force` as this may break your copy of the handout code. If this happens to you, please restart with a fresh copy of the handout.)
 


### PR DESCRIPTION
Sorry, I don't understand Jekyll or if this is the best way to do it.

The image showed up fine on the deploy preview, but it broke on the live site. The rendered HTML was referencing:

`https://neu-se.github.io/CS4530-Spring-2024/assignments/npm-warnings.jpg`

But the image was uploaded to:

`https://neu-se.github.io/CS4530-Spring-2024/Assignments/ip1/npm-warnings.jpg`.